### PR TITLE
Version 2.0

### DIFF
--- a/.github/workflows/CIBuild.yml
+++ b/.github/workflows/CIBuild.yml
@@ -20,7 +20,7 @@ jobs:
       uses: einaregilsson/build-number@v2 
       with:
         token: ${{secrets.github_token}}
-        prefix: vOne
+        prefix: vTwo
          
     - name: setup-msbuild
       uses: microsoft/setup-msbuild@v1
@@ -47,10 +47,10 @@ jobs:
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       with:
-        tag_name: 1.${{ steps.buildnumber.outputs.build_number }}
-        release_name: Release 1.${{ steps.buildnumber.outputs.build_number }}
+        tag_name: 2.${{ steps.buildnumber.outputs.build_number }}
+        release_name: Release 2.${{ steps.buildnumber.outputs.build_number }}
         body: |
-          Version 1.${{ steps.buildnumber.outputs.build_number }} 
+          Version 2.${{ steps.buildnumber.outputs.build_number }} 
           ${{github.event.head_commit.message}}
         draft: false
         prerelease: false

--- a/CastIntoGeneratorBiz/CastIntoCodeGenerator.cs
+++ b/CastIntoGeneratorBiz/CastIntoCodeGenerator.cs
@@ -98,7 +98,7 @@ namespace CastIntoGeneratorBiz
                 {
                     ClassNamesFound = true;
                     var Nomi = _GetClassNames(rigaSplittata);
-                    sb.AppendLine($"        public static T CastInto<T>(this {Nomi.ClassName} input, T output = default) where T : {Nomi.ClassName}");
+                    sb.AppendLine($"        public static T CastInto<T>(this {Nomi.ClassName} input, T output) where T : {Nomi.ClassName}");
                     sb.AppendLine("        {");
                     if(Nomi.BaseClassesList.Count > 0)
                     {

--- a/CastIntoGeneratorBiz/CastIntoCodeGenerator.cs
+++ b/CastIntoGeneratorBiz/CastIntoCodeGenerator.cs
@@ -98,19 +98,16 @@ namespace CastIntoGeneratorBiz
                 {
                     ClassNamesFound = true;
                     var Nomi = _GetClassNames(rigaSplittata);
-                    sb.AppendLine($"        public static T CastInto<T>(this {Nomi.ClassName} input, T output = default) where T : {Nomi.ClassName}, new()");
+                    sb.AppendLine($"        public static T CastInto<T>(this {Nomi.ClassName} input, T output = default) where T : {Nomi.ClassName}");
                     sb.AppendLine("        {");
-                    sb.AppendLine("            if (output == null)");
-                    sb.AppendLine("                output = new T();");
                     if(Nomi.BaseClassesList.Count > 0)
                     {
-                        sb.AppendLine();
                         foreach (string BaseClass in Nomi.BaseClassesList)
                         {
                             sb.AppendLine($"            (input as {BaseClass}).CastInto(output);");
                         }
+                        sb.AppendLine();
                     }
-                    sb.AppendLine();
                 }
                 else if (rigaSplittata.Length > 2 && rigaSplittata[2].StartsWith("{"))
                 { sb.AppendLine(_GetCastLine(rigaSplittata[1], rigaSplittata[0])); }

--- a/README.md
+++ b/README.md
@@ -3,11 +3,8 @@
 A simple tool made to implement an in house pattern for casting c# classes into derived or otherwise compatible versions of themselfs
 
 ```csharp
-public static T CastInto<T>(this TYPE input, T output = default) where T : TYPE, new()
+public static T CastInto<T>(this TYPE input, T output) where T : TYPE
         {
-            if (output == null)
-                output = new T();
-
             BASETYPE.CastInto(input, output); // (Only in case TYPE dervies from BASETYPE, use the direct parent of the type and fill the chain accordingly to the top)
 
             output.PROPERTY1 = input.PROPERTY1; // (Only the properties specific to this TYPE, not ones in base types)


### PR DESCRIPTION
removed the prerequisite on the generic argument to have a new() contructor, as it's just as practical in all situation to just specify you're casting into a new instance of the object by creating it as you pass it as an argument, rather than leaving the argument blank (which requires you to specify the generic type in the <> brackets anyways).

Since this change makes the methods not compatible with previous ones (you can't extend classes by calling previous castinto because now you can't guarantee the new()) you have to correct previous methods when extending them, hence the new major version number 